### PR TITLE
Kevin tolentino protractor logout

### DIFF
--- a/e2e/protractor.conf.js
+++ b/e2e/protractor.conf.js
@@ -7,8 +7,8 @@ exports.config = {
   allScriptsTimeout: 110000,
   specs: [
     //'./src/**/*.e2e-spec.ts' // run all the testing scripts
-    //'./src/app.e2e-spec.ts',
-    './src/journey.e2e-spec.ts' // run this specific script
+    './src/app.e2e-spec.ts'
+    // './src/journey.e2e-spec.ts' // run this specific script
   ],
   capabilities: {
     'browserName': 'chrome'

--- a/e2e/src/app.e2e-spec.ts
+++ b/e2e/src/app.e2e-spec.ts
@@ -91,6 +91,11 @@ describe('navigate around the maintab', () => {
         await browser.sleep(3000);
         expect(await app.currentUrl()).toContain('profile');
     });
+    it('should click the logout button', async () => {
+        await app.clickElement('#logoutButton')
+        await browser.sleep(3000);
+        expect(await showfeature.signinButtonIsPresent()).toBeTruthy();
+    })
 
 });
 

--- a/e2e/src/app.e2e-spec.ts
+++ b/e2e/src/app.e2e-spec.ts
@@ -81,3 +81,8 @@ describe('navigate around the maintab', () => {
     });
 
 });
+
+//steps
+//1 - click the back button (id="clickback")
+//2 - click the settings tabs
+//3 - click the logout tab logout

--- a/e2e/src/app.e2e-spec.ts
+++ b/e2e/src/app.e2e-spec.ts
@@ -78,28 +78,25 @@ describe('navigate around the maintab', () => {
     it('should load the edit profile page', async () => {
         await maintab.clickTabButton('#edit-profile-button'); // click on edit profile
         await about.waitUntilVisible(); // wait until about page is visible
-        await browser.sleep(3000);
         expect(app.headerIsPresent(null, '#about-me-header')).toBeTruthy(); // the about me header is present
     });
+
     it('should click the back button', async () => {
-        await app.clickElement('#clickback')
-        await browser.sleep(3000);
+        await app.clickElement('#clickback') // click the back button
         expect(app.headerIsPresent(null, '#about-me-header')).toBeTruthy(); // the about me header is present
     });
+
     it('should click the Settings button', async () => {
-        await app.clickElement('#dashboardSettingsButton')
-        await browser.sleep(3000);
-        expect(await app.currentUrl()).toContain('profile');
+        await app.clickElement('#dashboardSettingsButton') // click the settings icon on the dashboard
+        await browser.sleep(1000); // tell webdriver to wait so page can be seen
+        expect(await app.currentUrl()).toContain('profile'); // it should contain /profile in url
     });
+
     it('should click the logout button', async () => {
-        await app.clickElement('#logoutButton')
-        await browser.sleep(3000);
-        expect(await showfeature.signinButtonIsPresent()).toBeTruthy();
+        await app.clickElement('#logoutButton') //click the logout button
+        await browser.sleep(1000); // tell webdriver to wait so sign in page can be seen
+        expect(await showfeature.signinButtonIsPresent()).toBeTruthy(); //it should contain signin button in header
+
     })
 
 });
-
-//steps
-//1 - click the back button (id="clickback")
-//2 - click the settings tabs
-//3 - click the logout tab logout

--- a/e2e/src/app.e2e-spec.ts
+++ b/e2e/src/app.e2e-spec.ts
@@ -86,6 +86,11 @@ describe('navigate around the maintab', () => {
         await browser.sleep(3000);
         expect(app.headerIsPresent(null, '#about-me-header')).toBeTruthy(); // the about me header is present
     });
+    it('should click the Settings button', async () => {
+        await app.clickElement('#dashboardSettingsButton')
+        await browser.sleep(3000);
+        expect(await app.currentUrl()).toContain('profile');
+    });
 
 });
 

--- a/e2e/src/app.e2e-spec.ts
+++ b/e2e/src/app.e2e-spec.ts
@@ -71,12 +71,19 @@ describe('navigate around the maintab', () => {
     it('should load the Me page', async () => {
         await maintab.clickTabButton('#tab-button-me'); // click on the Me tab
         await me.waitUntilVisible(); // wait for me to be visible
+        await browser.sleep(3000);
         expect(await app.currentUrl()).toContain('app/me');
     });
 
     it('should load the edit profile page', async () => {
         await maintab.clickTabButton('#edit-profile-button'); // click on edit profile
         await about.waitUntilVisible(); // wait until about page is visible
+        await browser.sleep(3000);
+        expect(app.headerIsPresent(null, '#about-me-header')).toBeTruthy(); // the about me header is present
+    });
+    it('should click the back button', async () => {
+        await app.clickElement('#clickback')
+        await browser.sleep(3000);
         expect(app.headerIsPresent(null, '#about-me-header')).toBeTruthy(); // the about me header is present
     });
 

--- a/e2e/src/app.po.ts
+++ b/e2e/src/app.po.ts
@@ -146,12 +146,10 @@ export class AppPage {
         return element(by.css('ion-action-sheet')).isPresent();
     }
 
-    async clickSettings(text) {
-        element.all(by.css('#userProfileSettings')).each(async (el) => {
-            if (await el.getText === text) {
-                el.click();
-            }
-        });
+    async clickSettings(elementId) {
+        const settingEl = element(by.css(elementId));
+        settingEl.click();
+        console.log('Log the element', settingEl);
     }
 }
 

--- a/e2e/src/app.po.ts
+++ b/e2e/src/app.po.ts
@@ -146,11 +146,9 @@ export class AppPage {
         return element(by.css('ion-action-sheet')).isPresent();
     }
 
-    async clickElement(parentTag: string, sel: string) {
-        const els = element.all(by.css(parentTag ? `${parentTag} ${this.tag} ${sel}` : `${this.tag} ${sel}`));
-        els.each(async (el) => {
-            if (el.isDisplayed()) {
-                await browser.wait(ExpectedConditions.elementToBeClickable(el), 10000);
+    async clickSettings(text) {
+        element.all(by.css('#userProfileSettings')).each(async (el) => {
+            if (await el.getText === text) {
                 el.click();
             }
         });

--- a/e2e/src/app.po.ts
+++ b/e2e/src/app.po.ts
@@ -90,6 +90,15 @@ class PageObjectBase {
             return false;
         }
     }
+
+    async signinButtonIsPresent() {
+        const signinButton = element(by.css('#signin'));
+        if (signinButton) {
+            return signinButton.isPresent();
+        } else {
+            return false;
+        }
+    }
 }
 
 export class AppPage {

--- a/e2e/src/app.po.ts
+++ b/e2e/src/app.po.ts
@@ -94,6 +94,8 @@ class PageObjectBase {
 
 export class AppPage {
 
+    protected tag: string;
+
     navigateTo() {
         return browser.get('/register');
     }
@@ -142,6 +144,16 @@ export class AppPage {
 
     actionsheetIsPresent() {
         return element(by.css('ion-action-sheet')).isPresent();
+    }
+
+    async clickElement(parentTag: string, sel: string) {
+        const els = element.all(by.css(parentTag ? `${parentTag} ${this.tag} ${sel}` : `${this.tag} ${sel}`));
+        els.each(async (el) => {
+            if (el.isDisplayed()) {
+                await browser.wait(ExpectedConditions.elementToBeClickable(el), 10000);
+                el.click();
+            }
+        });
     }
 }
 

--- a/e2e/src/app.po.ts
+++ b/e2e/src/app.po.ts
@@ -146,10 +146,13 @@ export class AppPage {
         return element(by.css('ion-action-sheet')).isPresent();
     }
 
-    async clickSettings(elementId) {
-        const settingEl = element(by.css(elementId));
-        settingEl.click();
-        console.log('Log the element', settingEl);
+    async clickElement(elementId) {
+        const selectedEl = element(by.css(elementId));
+        selectedEl.click();
+    }
+
+    logoutButtonIsPresent() {
+        return element(by.css('#logoutButton')).isPresent();
     }
 }
 

--- a/e2e/src/app.po.ts
+++ b/e2e/src/app.po.ts
@@ -152,7 +152,7 @@ export class AppPage {
     }
 
     logoutButtonIsPresent() {
-        return element(by.css('#logoutButton')).isPresent();
+        return element(by.css('#logoutButton')).isPresent(); // is this always present on the DOM?
     }
 }
 

--- a/e2e/src/app.po.ts
+++ b/e2e/src/app.po.ts
@@ -102,9 +102,6 @@ class PageObjectBase {
 }
 
 export class AppPage {
-
-    protected tag: string;
-
     navigateTo() {
         return browser.get('/register');
     }

--- a/e2e/src/journey.e2e-spec.ts
+++ b/e2e/src/journey.e2e-spec.ts
@@ -100,16 +100,16 @@ describe('join journey and leave journey', () => {
     });
 
     it('should click the Settings tab', async () => {
-        await app.clickSettings('#userProfileSettings') // to click
-        await browser.sleep(3000);
-        expect(await app.currentUrl()).toContain('profile') //expect the url to change in the address bar
+        await app.clickElement('#userProfileSettings') // to click the settings tab
+        await browser.sleep(3000); // wait for browser to stabilize
+        expect(await app.currentUrl()).toContain('profile') //expect the url to change in the address bar to have string profile
     });
 
-    // it('should click the logout button', () => {
-    //     //click the privacy and settings tab
-    //     //click the ion-button to sign out
-    //     //expect ion-button with #signin to be present
-    // })
+    it('should click the logout button', async () => {
+        await app.clickElement('#logoutButton') // click ion-item with id logoutButton
+        await browser.sleep(3000); // wait for browser to stabilize
+        expect(await app.currentUrl()).toContain('activity') //expect the url to change in the address bar to have string profile
+    })
 
     //Pseudocode
     //1.Describe the expectations for the test spec

--- a/e2e/src/journey.e2e-spec.ts
+++ b/e2e/src/journey.e2e-spec.ts
@@ -100,10 +100,9 @@ describe('join journey and leave journey', () => {
     });
 
     it('should click the Settings tab', async () => {
-        await app.clickSettings('Settings') // to click
+        await app.clickSettings('#userProfileSettings') // to click
         await browser.sleep(3000);
         expect(await app.currentUrl()).toContain('profile') //expect the url to change in the address bar
-
     });
 
     // it('should click the logout button', () => {

--- a/e2e/src/journey.e2e-spec.ts
+++ b/e2e/src/journey.e2e-spec.ts
@@ -100,14 +100,14 @@ describe('join journey and leave journey', () => {
     });
 
     it('should click the Settings tab', async () => {
-        await app.clickElement('#userProfileSettings') // to click the settings tab
-        await browser.waitForAngular(); // wait for browser to stabilize
-        expect(await app.currentUrl()).toContain('profile'); //expect the url to change in the address bar to have string profile
+        await app.clickElement('#userProfileSettings')
+        await browser.waitForAngular();
+        expect(await app.currentUrl()).toContain('profile');
     });
 
     it('should click the logout button', async () => {
-        await app.clickElement('#logoutButton') // click ion-item with id logoutButton
-        await browser.waitForAngular(); // wait for browser to stabilize
-        expect(await showfeature.signinButtonIsPresent()).toBeTruthy(); //expect the signin button to be present
+        await app.clickElement('#logoutButton')
+        await browser.waitForAngular();
+        expect(await showfeature.signinButtonIsPresent()).toBeTruthy();
     })
 });

--- a/e2e/src/journey.e2e-spec.ts
+++ b/e2e/src/journey.e2e-spec.ts
@@ -99,9 +99,16 @@ describe('join journey and leave journey', () => {
         expect(await showfeature.headerIsPresent('app-main-tab', '#click-to-join')).toBeTruthy();
     });
 
-    it('should click the Settings tab', );
+    it('should click the Settings tab', async () => {
+        await app.clickElement('app-main-tab', '#userProfileSettings'); // to click the Settings ion-item
+        expect(await app.currentUrl()).toContain('app/user/profile') //expect the url to change in the address bar
+    });
 
-    it('should click the logout button', )
+    it('should click the logout button', () => {
+        //click the privacy and settings tab
+        //click the ion-button to sign out
+        //expect ion-button with #signin to be present
+    })
 
 
 

--- a/e2e/src/journey.e2e-spec.ts
+++ b/e2e/src/journey.e2e-spec.ts
@@ -102,13 +102,14 @@ describe('join journey and leave journey', () => {
     it('should click the Settings tab', async () => {
         await app.clickElement('#userProfileSettings') // to click the settings tab
         await browser.sleep(3000); // wait for browser to stabilize
-        expect(await app.currentUrl()).toContain('profile') //expect the url to change in the address bar to have string profile
+        expect(await app.currentUrl()).toContain('profile'); //expect the url to change in the address bar to have string profile
     });
 
     it('should click the logout button', async () => {
         await app.clickElement('#logoutButton') // click ion-item with id logoutButton
-        await browser.sleep(3000); // wait for browser to stabilize
-        expect(await app.currentUrl()).toContain('activity') //expect the url to change in the address bar to have string profile
+        // await app.waitUntilElementInvisible('#logoutButton');
+        expect(await showfeature.headerIsPresent('app-main-tab', '#signin')).toBeTruthy();
+        // expect(await app.logoutButtonIsPresent()).toBeFalsy(); //expect the logout button to not be present on the page
     })
 
     //Pseudocode

--- a/e2e/src/journey.e2e-spec.ts
+++ b/e2e/src/journey.e2e-spec.ts
@@ -100,15 +100,17 @@ describe('join journey and leave journey', () => {
     });
 
     it('should click the Settings tab', async () => {
-        await app.clickElement('app-main-tab', '#userProfileSettings'); // to click the Settings ion-item
-        expect(await app.currentUrl()).toContain('app/user/profile') //expect the url to change in the address bar
+        await app.clickSettings('Settings') // to click
+        await browser.sleep(3000);
+        expect(await app.currentUrl()).toContain('profile') //expect the url to change in the address bar
+
     });
 
-    it('should click the logout button', () => {
-        //click the privacy and settings tab
-        //click the ion-button to sign out
-        //expect ion-button with #signin to be present
-    })
+    // it('should click the logout button', () => {
+    //     //click the privacy and settings tab
+    //     //click the ion-button to sign out
+    //     //expect ion-button with #signin to be present
+    // })
 
 
     //to do: copy selectElement method to AppPage class

--- a/e2e/src/journey.e2e-spec.ts
+++ b/e2e/src/journey.e2e-spec.ts
@@ -98,4 +98,16 @@ describe('join journey and leave journey', () => {
         await app.waitUntilElementVisible('app-main-tab #click-to-join');
         expect(await showfeature.headerIsPresent('app-main-tab', '#click-to-join')).toBeTruthy();
     });
+
+    it('should click the Settings tab', );
+
+    it('should click the logout button', )
+
+
+
+
+
+    //Pseudocode
+    //1.Describe the expectations for the test spec
+    //2.
 });

--- a/e2e/src/journey.e2e-spec.ts
+++ b/e2e/src/journey.e2e-spec.ts
@@ -101,18 +101,13 @@ describe('join journey and leave journey', () => {
 
     it('should click the Settings tab', async () => {
         await app.clickElement('#userProfileSettings') // to click the settings tab
-        await browser.sleep(3000); // wait for browser to stabilize
+        await browser.waitForAngular(); // wait for browser to stabilize
         expect(await app.currentUrl()).toContain('profile'); //expect the url to change in the address bar to have string profile
     });
 
     it('should click the logout button', async () => {
         await app.clickElement('#logoutButton') // click ion-item with id logoutButton
-        // await app.waitUntilElementInvisible('#logoutButton');
-        expect(await showfeature.headerIsPresent('app-main-tab', '#signin')).toBeTruthy();
-        // expect(await app.logoutButtonIsPresent()).toBeFalsy(); //expect the logout button to not be present on the page
+        await browser.waitForAngular(); // wait for browser to stabilize
+        expect(await showfeature.signinButtonIsPresent()).toBeTruthy(); //expect the signin button to be present
     })
-
-    //Pseudocode
-    //1.Describe the expectations for the test spec
-    //2.
 });

--- a/e2e/src/journey.e2e-spec.ts
+++ b/e2e/src/journey.e2e-spec.ts
@@ -111,7 +111,7 @@ describe('join journey and leave journey', () => {
     })
 
 
-
+    //to do: copy selectElement method to AppPage class
 
 
     //Pseudocode

--- a/e2e/src/journey.e2e-spec.ts
+++ b/e2e/src/journey.e2e-spec.ts
@@ -112,10 +112,6 @@ describe('join journey and leave journey', () => {
     //     //expect ion-button with #signin to be present
     // })
 
-
-    //to do: copy selectElement method to AppPage class
-
-
     //Pseudocode
     //1.Describe the expectations for the test spec
     //2.

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -50,7 +50,7 @@
             </ion-item>
           </ion-menu-toggle>
           <ion-menu-toggle auto-hide="false">
-            <ion-item [routerLink]="['/app/user/profile']">
+            <ion-item id="userProfileSettings" [routerLink]="['/app/user/profile']">
               <ion-icon slot="start" name="cog"></ion-icon>
               <ion-label>Settings</ion-label>
             </ion-item>

--- a/src/app/pages/user/dashboard/dashboard.page.html
+++ b/src/app/pages/user/dashboard/dashboard.page.html
@@ -40,7 +40,7 @@
         {{userData.user.first_name}} {{userData.user.last_name}}
       </ion-label>
     </ion-item>
-    <ion-button [routerLink]="['/app/user/profile']" *ngIf="!modalPage && userData.user && platform.width() < 768" slot="end" fill="clear" color="grey">
+    <ion-button id="dashboardSettingsButton" [routerLink]="['/app/user/profile']" *ngIf="!modalPage && userData.user && platform.width() < 768" slot="end" fill="clear" color="grey">
       <ion-icon name="settings-outline"></ion-icon>
     </ion-button>
     <ion-buttons slot="end" *ngIf="!userData.user">
@@ -144,7 +144,7 @@
             <ion-slides class="program-slides" [options]="{slidesPerView: 2.2, grabCursor: true, updateOnWindowResize: true}" *ngIf="journeys && journeys.length && platform.width() < 768">
               <ion-slide class="program-slide" *ngFor="let journey of journeys; trackBy: customTrackBy" [hidden]="!((journey.matrix_string[0][0].toLowerCase().includes(searchKeyword.toLowerCase()) || journey.resource['en-US'].value[0].toLowerCase().includes(searchKeyword.toLowerCase())))">
                 <ion-card id="journey-card" class="program-card" (click)="openProgram($event, journey)">
-                  <ion-card-header class="ion-no-padding"> 
+                  <ion-card-header class="ion-no-padding">
                     <div class="program-photo-container">
                       <img class="program-photo" [src]="(journey.assets && journey.assets.length && journey.assets[0]) | background: journey._id" />
                     </div>

--- a/src/app/pages/user/user.page.html
+++ b/src/app/pages/user/user.page.html
@@ -50,7 +50,7 @@
             <ion-icon slot="start" name="notifications" *ngIf="platform.width() < 768"></ion-icon>
             <ion-label [ngClass]="{ 'bold-font': (platform.width() >= 768) && router.url.includes('/notifications')}">Notifications</ion-label>
           </ion-item>
-          <ion-item (click)="logout($event)">
+          <ion-item id="logoutButton" (click)="logout($event)">
             <ion-icon slot="start" name="log-out" *ngIf="platform.width() < 768"></ion-icon>
             <ion-label>Log Out</ion-label>
           </ion-item>


### PR DESCRIPTION
Click the following link to view a video demo of the test in real-time (if interested, installing the [loom chrome extension](https://chrome.google.com/webstore/detail/loom-for-chrome/liecbddmkiiihnedobmlmillhodjkdmb?hl=en-US) allows for video to be viewed directly on this page): https://www.loom.com/share/3470f265810e4d99bbcd75418aa14ca1

**Notes:**

- I used `browser.waitForAngular()` instead of `browser.sleep(ms)`, which results in the last two steps being fast
- Let me know if you want to implement for mobile sizing as well. I tried it, and it didn't past the test since it will have to click the ion-menu-toggle element 
- Test success screenshot for browser below:
![kevin-tolentino-protractor-logout 1](https://user-images.githubusercontent.com/56104566/92162113-7d612180-ede6-11ea-997b-f8d077e361d7.png)
