### PR TITLE
Fix share extension double post bug

### DIFF
--- a/ios/App/ShareExtension/ShareViewController.swift
+++ b/ios/App/ShareExtension/ShareViewController.swift
@@ -50,7 +50,7 @@ class ShareViewController: SLComposeServiceViewController {
                 })
             }
         }
-        guard let text = textView.text else {return}
+        textView.text = "";
         
     }
     


### PR DESCRIPTION
Removed the default text from the textform of the share extension
window. This fixes the use case where the user just shares text.